### PR TITLE
Go client flux

### DIFF
--- a/performance-go/go.mod
+++ b/performance-go/go.mod
@@ -1,0 +1,3 @@
+module performance-go
+
+go 1.17

--- a/performance-go/handlers/client.go
+++ b/performance-go/handlers/client.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"performance-go/data"
+	"strconv"
+)
+
+type Client struct {
+	l *log.Logger
+}
+
+func NewClient(l *log.Logger) *Client {
+	return &Client{l}
+}
+
+func (c *Client) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		delay, _ := strconv.ParseInt(r.URL.Query().Get("delay"), 10, 32)
+		resp, err := http.Get(fmt.Sprintf("http://localhost:8083/products?delay=%d", delay))
+		if err != nil {
+			c.l.Print(err)
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+		var products []data.Product
+		err = json.NewDecoder(resp.Body).Decode(&products)
+		if err != nil {
+			c.l.Print(err)
+		}
+		err = json.NewEncoder(rw).Encode(products)
+		if err != nil {
+			c.l.Print(err)
+		}
+		return
+	}
+	rw.WriteHeader(http.StatusMethodNotAllowed)
+}

--- a/performance-go/handlers/products.go
+++ b/performance-go/handlers/products.go
@@ -3,22 +3,22 @@ package handlers
 import (
 	"log"
 	"net/http"
-	"performance-api-webflux-vs-mvc-vs-golang/performance-go/data"
+	"performance-go/data"
 	"strconv"
 	"time"
 )
 
 // Products ...
-type Products struct {
+type ProductsHandler struct {
 	l *log.Logger
 }
 
 // NewProducts ...
-func NewProducts(l *log.Logger) *Products {
-	return &Products{l}
+func NewProducts(l *log.Logger) *ProductsHandler {
+	return &ProductsHandler{l}
 }
 
-func (p *Products) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+func (p *ProductsHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	if r.Method == http.MethodGet {
 		p.getProducts(rw, r)
@@ -27,9 +27,7 @@ func (p *Products) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	rw.WriteHeader(http.StatusMethodNotAllowed)
 }
 
-func (p *Products) getProducts(rw http.ResponseWriter, r *http.Request) {
-	//p.l.Println("Handle GET Product")
-
+func (p *ProductsHandler) getProducts(rw http.ResponseWriter, r *http.Request) {
 	delay, _ := strconv.ParseInt(r.URL.Query().Get("delay"), 10, 32)
 	time.Sleep(time.Duration(delay) * time.Millisecond)
 

--- a/performance-spring-webflux/pom.xml
+++ b/performance-spring-webflux/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.2.RELEASE</version>
+		<version>2.6.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.filipe.performance</groupId>
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 	</properties>
 
 	<dependencies>

--- a/performance-spring-webflux/src/main/java/com/filipe/performance/controller/ClientController.java
+++ b/performance-spring-webflux/src/main/java/com/filipe/performance/controller/ClientController.java
@@ -7,21 +7,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
+import com.filipe.performance.dto.Product;
 
 @RestController
 public class ClientController {
 	
+	private final WebClient wc = WebClient.builder()
+											.baseUrl("http://localhost:8082")
+											.build();
 
     @GetMapping(value = "/performance-webflux")
-    public Mono<List> getUserUsingWebfluxWebclient(@RequestParam long delay) {
-        return WebClient.builder()
-        		.baseUrl("http://localhost:8082")
-        		.build()
-        		.get()
+    public Flux<Product> getUserUsingWebfluxWebclient(@RequestParam long delay) {
+        return wc.get()
         		.uri("/product/?delay={delay}", delay)
         		.retrieve()
-        		.bodyToMono(List.class);
+        		.bodyToFlux(Product.class);
     }
 
 }

--- a/performance-spring-webflux/src/main/java/com/filipe/performance/controller/ProductController.java
+++ b/performance-spring-webflux/src/main/java/com/filipe/performance/controller/ProductController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.filipe.performance.dto.Product;
 
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 @RestController
 @RequestMapping("/product")
@@ -33,7 +33,7 @@ public class ProductController {
 
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
-	public Mono<List<Product>> getProducts(@RequestParam long delay) {		
-		return Mono.just(products).delayElement(Duration.ofMillis(delay));		
+	public Flux<Product> getProducts(@RequestParam long delay) {		
+		return Flux.fromIterable(products).delaySequence(Duration.ofMillis(delay));		
 	}
 }


### PR DESCRIPTION
- in webflux - use Flux instead of Mono, use prebuilt WebClient
- in go - use http client to simulate same approach of getting data from upstream

used vegeta to compare performance

echo "GET http://localhost:8082/performance-webflux/?delay=100" | vegeta attack -duration=30s -rate=2000 | vegeta report

echo "GET http://localhost:8083/performance-go?delay=100" | vegeta attack -duration=30s -rate=2000 | vegeta report


results approximately the same

go results:

Requests      [total, rate, throughput]         60000, 2000.04, 1993.38
Duration      [total, attack, wait]             30.1s, 29.999s, 100.269ms
Latencies     [min, mean, 50, 90, 95, 99, max]  100.176ms, 100.321ms, 100.242ms, 100.296ms, 100.38ms, 101.342ms, 128.321ms
Bytes In      [total, mean]                     20520000, 342.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:60000 

java results (JDK 15):

Requests      [total, rate, throughput]         60000, 2000.04, 1993.35
Duration      [total, attack, wait]             30.1s, 29.999s, 100.804ms
Latencies     [min, mean, 50, 90, 95, 99, max]  100.375ms, 100.82ms, 100.709ms, 101.191ms, 101.344ms, 103.529ms, 130.531ms
Bytes In      [total, mean]                     20460000, 341.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:60000  


MacBook Pro 2019:
1.4 GHz Quad-Core Intel Core i5
RAM 8GB

AWS t2.nano test results:

GO:
echo "GET http://52.205.255.129/benchmark/go/performance-go?delay=100" | vegeta attack -duration=10s -rate=100 | vegeta report

Requests      [total, rate, throughput]         1000, 100.09, 98.01
Duration      [total, attack, wait]             10.204s, 9.991s, 212.431ms
Latencies     [min, mean, 50, 90, 95, 99, max]  206.585ms, 259.641ms, 212.934ms, 380.893ms, 456.248ms, 859.284ms, 966.788ms
Bytes In      [total, mean]                     342000, 342.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:1000 

JAVA SPRING WEBFLUX (JDK 17, G1 Garbage Collector):
echo "GET http://52.205.255.129/benchmark/java/performance-webflux/?delay=100" | vegeta attack -duration=10s -rate=100 | vegeta report

Requests      [total, rate, throughput]         1000, 100.11, 98.01
Duration      [total, attack, wait]             10.203s, 9.989s, 213.537ms
Latencies     [min, mean, 50, 90, 95, 99, max]  207.053ms, 238.573ms, 209.859ms, 294.837ms, 363.764ms, 689.922ms, 857.639ms
Bytes In      [total, mean]                     341000, 341.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:1000



RATE 400 RESULTS:

GO:
Requests      [total, rate, throughput]         12000, 400.03, 395.29
Duration      [total, attack, wait]             30.357s, 29.997s, 359.855ms
Latencies     [min, mean, 50, 90, 95, 99, max]  204.324ms, 321.686ms, 259.348ms, 528.879ms, 649.594ms, 888.905ms, 1.392s
Bytes In      [total, mean]                     4104000, 342.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:12000  

JAVA:
Requests      [total, rate, throughput]         12000, 400.04, 393.79
Duration      [total, attack, wait]             30.473s, 29.997s, 476.159ms
Latencies     [min, mean, 50, 90, 95, 99, max]  204.649ms, 290.306ms, 246.281ms, 418.615ms, 552.438ms, 763.382ms, 1.067s
Bytes In      [total, mean]                     4092000, 341.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:12000 



AWS t4g.nano test results:
-duration=10s -rate=200

GO:
Requests      [total, rate, throughput]         2000, 200.11, 196.01
Duration      [total, attack, wait]             10.204s, 9.995s, 209.014ms
Latencies     [min, mean, 50, 90, 95, 99, max]  206.71ms, 226.72ms, 211.289ms, 217.172ms, 354.252ms, 537.788ms, 1s
Bytes In      [total, mean]                     684000, 342.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:2000  

JAVA:
Requests      [total, rate, throughput]         2000, 200.10, 83.98
Duration      [total, attack, wait]             23.814s, 9.995s, 13.819s
Latencies     [min, mean, 50, 90, 95, 99, max]  483.731ms, 2.226s, 1.674s, 4.243s, 6.163s, 10.45s, 16.469s
Bytes In      [total, mean]                     682000, 341.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:2000  


-duration=10s -rate=400
GO:
Requests      [total, rate, throughput]         4000, 400.11, 391.08
Duration      [total, attack, wait]             10.228s, 9.997s, 230.768ms
Latencies     [min, mean, 50, 90, 95, 99, max]  205.504ms, 288.194ms, 215.331ms, 562.174ms, 663.671ms, 787.317ms, 1.237s
Bytes In      [total, mean]                     1368000, 342.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           100.00%
Status Codes  [code:count]                      200:4000  
JAVA:
Could not obtain results without error.


